### PR TITLE
商品購入確認ページ作成_01

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,4 +7,5 @@
 @import "./font-awesome";
 @import "items_index";
 @import "items_show";
-@import "items_new"
+@import "items_new";
+@import "items_create";

--- a/app/assets/stylesheets/items_create.scss
+++ b/app/assets/stylesheets/items_create.scss
@@ -1,0 +1,96 @@
+.item-review{
+  height: 200px;
+  display: flex;
+  &__image{
+    background-color: yellow;
+    height: 150px;
+    width: 130px;
+    margin: 20px;
+  }
+  &__wrapper{
+    display: flex;
+    flex-direction: column;
+    margin: 20px;
+    &__title{
+      
+    }
+    &__price{
+      
+    }
+  }
+  
+}
+
+.payment-amount{
+  height: 150px;
+  display: flex;
+  &__title{
+    width: 65%;
+    font-size: 20px;
+  }
+  &__amount{
+    width: 35%;
+    font-size: 30px;
+  }
+}
+
+.payment-methods{
+  height: 200px;
+  &__top{
+    display: flex;
+    justify-content: space-between;
+    margin-right: 50px;
+  }
+  &__bottom{
+    display: flex;
+    flex-direction: column;
+    &__method{
+      
+    }
+    &__card-no{
+      
+    }
+    &__dard-valid{
+      
+    }
+    &__card-logo{
+      
+    }
+    
+  }
+}
+
+.delivery-destination{
+  height: 200px;
+  &__top{
+    display: flex;
+    justify-content: space-between;
+    margin-right: 50px;
+  }
+  &__bottom{
+    display: flex;
+    flex-direction: column;
+  }
+  
+}
+
+.submit-btn{
+  color: white;
+  background-color: red;
+  text-align: center;
+  height: 50px;
+  border-radius: 5px;
+  line-height: 50px;
+}
+
+hr{
+  margin-bottom: 20px;
+}
+
+.title{
+  font-size: 20px;
+}
+
+.btn{
+  color: $main-blue;
+}

--- a/app/assets/stylesheets/items_new.scss
+++ b/app/assets/stylesheets/items_new.scss
@@ -108,3 +108,4 @@ span {
 form{
   align-items: center;
 }
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,8 @@ class ItemsController < ApplicationController
     10.times{ @item.images.build }
   end
 
+
+
   def create
     Item.create(item_params)
 

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -1,0 +1,56 @@
+.main
+  .show_main
+    .content
+      .item_box
+        .item_box__item_title
+          購入内容の確認
+        %hr
+        .item-review
+          .item-review__image
+            写真
+          .item-review__wrapper
+            .item-review__wrapper__title
+              手作りキャットタワー
+            .item-review__wrapper__price
+              3500円(税込み) 着払い          
+        %hr
+        .payment-amount
+          .payment-amount__title
+            支払金額
+          .payment-amount__amount
+            3500円
+        %hr
+
+        .payment-methods
+          .payment-methods__top
+            .title
+              %h1 支払方法
+            .btn
+              %h2 変更する
+          .payment-methods__bottom
+            .payment-methods__bottom__method
+              支払い方法
+            .payment-methods__bottom__card-no
+              ***********4460
+            .payment-methods__bottom__card-valid
+              有効期限 05/23
+            .payment-methods__bottom__card-logo
+              ロゴ
+        %hr
+        .delivery-destination
+          .delivery-destination__top
+            .title
+              配達先
+            .btn
+              変更する
+          .delivery-destination__bottom
+            .delivery-destination__bottom__post-code
+              〒145-0082
+            .delivery-destination__bottom__address
+              東京都大田区あああ
+            .delivery-destination__bottom__name
+              池田尚仁
+        %hr
+        .submit-btn
+          購入する
+

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -182,7 +182,7 @@
 
 
 .post-item-btn
-  = link_to items_path, class:"post-item-btn"  do
+  = link_to new_item_path, class:"post-item-btn"  do
     .post-item-btn__title
       出品する
     .post-item-btn__image

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -79,3 +79,5 @@
             
             = f.submit "出品する" ,class: "send_btn"
             = link_to "もどる", "#", class: "back_btn"
+
+

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -14,6 +14,6 @@
         %div テキスト
   .footer__bottom
     .footer__bottom__logo
-      %div フリマ
+      = link_to (image_tag 'logo/logo-white.png',size: '130x40'), items_path
     .footer__bottom__text
       %div ©︎furima

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,7 +2,7 @@
   .header__wrapper
     .header__wrapper__top
       .header__wrapper__top__logo
-        = link_to (image_tag 'logo/logo.png'), "#"
+        = link_to (image_tag 'logo/logo.png'), items_path
       .header__wrapper__top__search-box
         .header__wrapper__top__search-box__window
           = form_with model: @user, url: items_path, id: 'search-input-id', class: 'search-input', local: true do |f|


### PR DESCRIPTION
what
view/items/create.html.haml
stylesheets/items_create.scss 記述

リンク先設定
出品するボタン→new_item_path
ヘッダーフッターロゴ→items_path

why
購入確認ページ実装しユーザー利便性向上のため