### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/assets/stylesheets/items_show.scss
+++ b/app/assets/stylesheets/items_show.scss
@@ -11,6 +11,7 @@
       .item_box{
         background-color: #fff;
         padding: 24px 40px 40px;
+        // position: relative;
         &__item_title {
           text-align: center;
           font-weight: bold;
@@ -67,6 +68,26 @@
                 font-weight: 400;
               }
             }
+          }
+        }
+        .delete-btn-wrapper{
+          // align-items:flex-end;
+          height: 50px;
+          width: 100%;
+          .delete_btn{
+            margin: 0 0 0 auto;
+            display: block;
+            height: 50px;
+            width: 80px;
+            background-color:$main-blue;
+            border-radius: 3px;
+            line-height: 50px;
+            text-align: center;
+            text-decoration: none;
+            color: white;
+              a{
+                
+              }
           }
         }
       }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,12 @@ class ItemsController < ApplicationController
     10.times{ @item.images.build }
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
 
 
   def create

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   mount_uploader :image, ImageUploader
-  has_many :images
+  has_many :images, dependent: :destroy
 
   accepts_nested_attributes_for :images # item保存時に、imageテーブルにレコードを保存するため
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -49,6 +49,9 @@
                   %th 発送日の目安
                   %td
                     = @item.shipping_date
+        .delete-btn-wrapper
+          -if user_signed_in?
+            = link_to "削除する", item_path(@item.id),method: :delete, class:"delete_btn"
       .comment_box
         // コメント機能実装する場合のみ利用
       %ul.item_links
@@ -61,6 +64,7 @@
             後ろの商品
             = icon('fa', 'angle-right')
       = link_to "＜カテゴリー名＞をもっとみる", "#", class: "category_link"
+
 
 
   .app-banner

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :destroy]
   resources :images, only: [:create]
 end


### PR DESCRIPTION
what
controllers/items_controller
→destroyアクション記述
→itemデータに合わせて写真も削除
views/items/show.html.hml
→削除ボタンを実装
→削除後は一旦トップページへリダイレクト
・ログインユーザーのみが削除実行可能

why
投稿商品を削除する機能を実装するため