### PR TITLE
商品情報機能作成_03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 config/secrets.yml
+public/uploads/*

--- a/app/assets/stylesheets/items_edit.scss
+++ b/app/assets/stylesheets/items_edit.scss
@@ -1,9 +1,7 @@
-.column_title__edit{
+.column_title__edit{ //newページと差異のある箇所のみ記述 (全体をつなげる際要リファクタリング)
   display: flex;
   flex-direction: column;
   .column_title__edit__wrapper{
-    // display: flex;
-    // justify-content: flex-start;
     .column_title___edit__wrapper__text{
       display: flex;
       justify-content: flex-start;
@@ -13,8 +11,6 @@
         padding: 5px 10px;
         line-height: 25px;
         height: 25px;
-    
-
       }
       p{
         color: #fff;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:edit, :show,:update]
   
   def index
 
@@ -16,14 +17,15 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
     @image = Image.find(params[:id])
   end
 
   def update
-    item= Item.find(params[:id])
-    item.update(item_params)
-    redirect_to root_path
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
 
@@ -37,7 +39,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
     @user = User.where(id: @item.seller_id)
   end
 
@@ -46,6 +47,11 @@ class ItemsController < ApplicationController
     params.require(:item).permit(
       :seller_id, :categories_id, :name, :description, :postage, :region_id, :shipping_date, :price, :condition, :status, images_attributes: [:id, :image]
     )
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
+
   end
 
 end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -15,7 +15,6 @@
         .image_form
           = form_with model: @item do |f|
             = f.fields_for :images do |img|
-              -# =image_tag img.image.url
               = img.file_field :image,class: "items_form"
               
             %hr


### PR DESCRIPTION
What
Views/items/edit.html.haml
stylesheets/items_edit.scss
items_controller
上記ファイルに編集機能作成
編集後は一旦トップページへrender

issue
画像が1枚しか編集できない
→5枚に変更必要

共通で使用しているcssの高さ合っておらず
一部ビュー崩れ有り

why
ユーザーが投稿商品の編集ができるよう実装