### PR TITLE
商品編集画面ページの商品画像表示機能を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'capistrano3-unicorn'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'rails-controller-testing'
 end
 
 group :development do
@@ -68,6 +69,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
+  gem 'faker', "~> 2.8"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.10.1)
+      i18n (>= 1.6, < 2)
     ffi (1.12.1)
     fog-aws (3.5.2)
       fog-core (~> 2.1)
@@ -236,6 +238,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.4.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -365,6 +371,7 @@ DEPENDENCIES
   devise
   erb2haml
   factory_bot_rails
+  faker (~> 2.8)
   fog-aws
   font-awesome-rails
   font-awesome-sass
@@ -379,6 +386,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.1)
+  rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/stylesheets/items_edit.scss
+++ b/app/assets/stylesheets/items_edit.scss
@@ -27,8 +27,9 @@
       }
     }
     .item_image{
-      height: 200px;
-      width: 200px;
+      height: 150px;
+      width: 150px;
+      object-fit: cover;
     }
   }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,7 +17,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @image = Image.find(params[:id])
+    @images = @item.images
   end
 
   def update

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,5 +11,4 @@ class Item < ApplicationRecord
     belongs_to_active_hash :shipping_date
   
     validates :name, :price, :condition_id, :postage_id, :region_id, :shipping_date_id, :description, :seller_id, :status, :categories_id, presence: true
-    
 end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -10,8 +10,9 @@
             .column_title___edit__wrapper__text
               %h1 出品画像
               %p 必須
-            =image_tag @image.image.url,class:"item_image"
-          %span 最大10枚まで登録できます
+              %span 最大4枚まで登録できます
+            - @images.each do |image|
+              = image_tag image.image.url, class:"item_image"
         .image_form
           = form_with model: @item do |f|
             = f.fields_for :images do |img|
@@ -43,8 +44,7 @@
                     %h1 商品の状態
                     %p 必須
                   = f.select :condition, [["--", 0], ["新品、未使用", 1],["未使用に近い", 2],["目立った傷や汚れなし", 3],["やや傷や汚れあり",4],["傷や汚れあり",5],["全体的に状態が悪い",6]], class: "items_form-c"
-                  -# %select{name: "---", size: 6}
-                    -# %option(value="新品")
+
             %hr
 
             .split

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,0 +1,43 @@
+# 途中で詰まりました。時間に余裕があれば手直しします
+
+# require 'rails_helper'
+
+# describe ItemsController do
+
+#   describe 'GET #index' do
+#     it "populates an array of items ordered by created_at DESC" do
+#       items = create_list(:item, 3)
+#       get :index
+#       expect(assigns(:items)).to match(items.sort{ |a, b| b.created_at <=> a.created_at } )
+#     end
+
+#     it "renders the :index template" do
+#       get :index
+#       expect(response).to render_template :index
+#     end
+#   end
+
+#   describe 'GET #new' do
+#     it "renders the :new template" do
+#       get :new
+#       expect(response).to render_template :new
+#     end
+#   end
+
+#   describe 'GET #edit' do
+#     it 'assigns the requested item to @item' do
+#       item = create(:item)
+#       get :item, params: { id: item }
+#       expect(assigns(:item)).to eq item
+#     end
+    
+#     it 'renders the :edit template' do
+#       item = create(:item)
+#       get :edit, params: { id: item }
+#       expect(response).to render_template :edit
+#     end
+#   end
+
+  
+
+# end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     seller_id         {1}
     status            {"exibiting"}
     categories_id     {1}
+    created_at        { Faker::Time.between(from: DateTime.now - 2, to: Datetime.now) }
   end
 
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Item do
-  describe '#create' do
 
+  describe '#create' do
     # 1.nameが空だとitemの登録ができない
     it "is invalid without a name" do
       item = build(:item, name: "")
@@ -85,6 +85,6 @@ describe Item do
       item = build(:item)
       expect(item).to be_valid
     end
-    
+        
   end
 end


### PR DESCRIPTION
# WHAT
・商品編集画面の商品写真のバグを改修
・itemに紐づいた写真を４枚表示できるように修正しました

# WHY
・item.idに紐づいたimageが表示されていなかったため

[![Image from Gyazo](https://i.gyazo.com/e91bb4534baab0a9a0c70cbed982c078.gif)](https://gyazo.com/e91bb4534baab0a9a0c70cbed982c078)