### PR TITLE
トップページのitemからitem#showへリンク追加、購入済みのitemは非表示に修正

### DIFF
--- a/app/assets/stylesheets/items_index.scss
+++ b/app/assets/stylesheets/items_index.scss
@@ -211,13 +211,16 @@
           padding: 10px;
           &__name{
             font-size: 16px;
+            color: black;
           }
           &__price-box{
             &__price{
               font-size: 16px;
+              color: black;
             }
             &__tax{
               font-size: 10px;
+              color: black;
             }
           }
         }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show,:update]
   
   def index
-    @items = Item.order('id DESC').limit(3)
+    @items = Item.order('id DESC').limit(3).where(status: "exibiting")
   end
 
   def new

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -97,18 +97,19 @@
       %p 新規投稿商品
       .items-wrapper
         - @items.each do |item|
-          .item__box
-            .item__box__image
-              - img = item.images[0]
-              = image_tag img.image.url, class: "item__box__content"
-            .item__box__body
-              .item__box__body__name
-                = item.name
-              .item__box__body__price-box
-                .item__box__body__price-box__price
-                  = item.price
-                .item__box__body__price-box__tax
-                  (税込)
+          = link_to item_path(item.id) do
+            .item__box
+              .item__box__image
+                - img = item.images[0]
+                = image_tag img.image.url, class: "item__box__content"
+              .item__box__body
+                .item__box__body__name
+                  = item.name
+                .item__box__body__price-box
+                  .item__box__body__price-box__price
+                    = "#{item.price}円"
+                  .item__box__body__price-box__tax
+                    (税込)
 
     .items_title
       %p アーカイバ


### PR DESCRIPTION
# WHAT
・トップページのitemのアイコンから、items#showページに遷移できるよう改修
・すでに購入済みの商品は、トップページに表示しないように改修

# WHY
・item#showページに遷移する方法が無かったため
・購入済みitemかどうかをビューで区別するよりも、そもそも表示をさせない方が工数が少ないから

[![Image from Gyazo](https://i.gyazo.com/52c36c97361129e164c1c5e2d5c07496.gif)](https://gyazo.com/52c36c97361129e164c1c5e2d5c07496)