### PR TITLE
トップページの商品名表示を12文字に制限

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -104,7 +104,7 @@
                 = image_tag img.image.url, class: "item__box__content"
                 .item__box__body
                   .item__box__body__name
-                    = item.name
+                    = item.name.truncate(12)
                   .item__box__body__price-box
                     .item__box__body__price-box__price
                       = "#{item.price}円"


### PR DESCRIPTION
# WHAT
・トップページの商品一覧で表示できる文字数を１２文字に制限しました

# WHY
・文字数の多い商品の場合にビューの崩れが起きる可能性をなくすため

[![Image from Gyazo](https://i.gyazo.com/c58e867bd5fa8158a331607ed66c60ea.gif)](https://gyazo.com/c58e867bd5fa8158a331607ed66c60ea)