### PR TITLE
マイページ遷移ボタンの作成

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -19,7 +19,8 @@
           = link_to 'ブランド', "#", method: :get
 
         .header__wrapper__bottom__find-box__brand
-          = link_to '詳細', "/items/1", method: :get
+          - if user_signed_in?
+            = link_to 'マイページ', user_path(current_user)
       .header__wrapper__bottom__login-box
         - if user_signed_in?
           .header__wrapper__bottom__login-box__regi-btn


### PR DESCRIPTION
# what
　トップページ 詳細 ボタンを マイページ遷移ボタンに変更
　[![Image from Gyazo](https://i.gyazo.com/a762cf3e2617a9ccf56ba9a172f2a110.gif)](https://gyazo.com/a762cf3e2617a9ccf56ba9a172f2a110)

#why
　マイページに遷移するボタンが存在しなかった事
　詳細ページは試験的に配置してた物であった為