### PR TITLE
商品詳細ページの写真表示のCSSを修正

### DIFF
--- a/app/assets/stylesheets/items_show.scss
+++ b/app/assets/stylesheets/items_show.scss
@@ -45,7 +45,6 @@
           }
           &__other_image {
             display: flex;
-            justify-content: space-between;
             .img_others {
               width: 180px;
               object-fit: cover;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,6 @@ ActiveRecord::Schema.define(version: 2020_02_11_151949) do
     t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "image_05"
     t.index ["item_id"], name: "index_images_on_item_id"
   end
 


### PR DESCRIPTION
# WHAT
・商品詳細ページの写真表示のCSSを修正

# WHY
・写真が３枚の時に、小さい写真が両端に寄ってしまいビューが崩れているように見えたため

[![Image from Gyazo](https://i.gyazo.com/1c289951a0bee979f98f1854ba7515b8.gif)](https://gyazo.com/1c289951a0bee979f98f1854ba7515b8)