### PR TITLE
未ログイン時に出品ボタンを押すとログインページに遷移するよう改修

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -143,10 +143,16 @@
 
 
 .post-item-btn
-  = link_to new_item_path, class:"post-item-btn"  do
-    .post-item-btn__title
-      出品する
-    .post-item-btn__image
-      = image_tag 'icon/icon_camera.png', size: '50x50'
-
+  - if user_signed_in?
+    = link_to new_item_path, class:"post-item-btn"  do
+      .post-item-btn__title
+        出品する
+      .post-item-btn__image
+        = image_tag 'icon/icon_camera.png', size: '50x50'
+  - else
+    = link_to user_session_path, class:"post-item-btn"  do
+      .post-item-btn__title
+        出品する
+      .post-item-btn__image
+        = image_tag 'icon/icon_camera.png', size: '50x50'
 = render 'shared/footer'


### PR DESCRIPTION
# WHAT
・未ログイン時に出品ボタンを押すとログインページに遷移するよう改修しました

# WHY
・未ログイン状態で出品ページに遷移し、出品ボタンを押した時に出品できないというバグがあったため

[![Image from Gyazo](https://i.gyazo.com/da1a7b7ef0baa21ef96373cb517181bb.gif)](https://gyazo.com/da1a7b7ef0baa21ef96373cb517181bb)