### PR TITLE
未ログイン時に購入手続きに進もうとするとログイン画面へ遷移

### DIFF
--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -23,4 +23,7 @@
               .item-detail-box__info__description
                 ="商品の説明:#{item.description}"
               .item-detail-box__info__link
-                = link_to "購入手続きに進む", item_purchase_index_path(item.id)
+                - if user_signed_in?
+                  = link_to "購入手続きに進む", item_purchase_index_path(item.id)
+                - else
+                  = link_to "購入手続きに進む", user_session_path

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,8 +32,7 @@
                 %tr
                   %th 出品者
                   %td
-                    - @user.each do |user|
-                      = user.nickname
+                    = @user[0].nickname
                 %tr
                   %th カテゴリー
                   %td 


### PR DESCRIPTION
# WHAT
・未ログイン時に購入手続きに進もうとするとログイン画面へ遷移するよう修正

# WHY
・未ログイン時に商品検索をして購入手続きに進むボタンを押すと、エラーが発生するため

[![Image from Gyazo](https://i.gyazo.com/e475b693fd6e75ba3f9b96da32633858.gif)](https://gyazo.com/e475b693fd6e75ba3f9b96da32633858)