### PR TITLE
商品出品ページの写真投稿フォームのビュー修正

### DIFF
--- a/app/assets/javascripts/new_items.js
+++ b/app/assets/javascripts/new_items.js
@@ -111,7 +111,7 @@ $(document).on('turbolinks:load', function(){
         //フォームの中身を削除 
         $(`#item_images_attributes_${id}_image`).val("");
         var count = $('.preview-box').length;
-        //5個めが消されたらラベルを表示
+        //4個めが消されたらラベルを表示
         if (count == 4) {
           $('.label-content').show();
         }
@@ -124,7 +124,7 @@ $(document).on('turbolinks:load', function(){
 
         //投稿編集時
         $(`#item_images_attributes_${id}__destroy`).prop('checked',true);
-        //5個めが消されたらラベルを表示
+        //4個めが消されたらラベルを表示
         if (count == 4) {
           $('.label-content').show();
         }

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -16,14 +16,14 @@
               .post__drop__box__container
                 .prev-content
                 .label-content
-                %label{for: "item_images_attributes_0_image", class: "abel-box", id: "label-box--0"}
-                  %pre.label-box__text-visible クリックしてファイルをアップロード
-              .hidden-content
-                = f.fields_for :images do |i|
-                  = i.file_field :image, class: "hidden-field"
-                  %input{class:"hidden-field", type: "file", name: "item[images_attributes][1][image]", id: "item_images_attributes_1_image" }
-                  %input{class:"hidden-field", type: "file", name: "item[images_attributes][2][image]", id: "item_images_attributes_2_image" }
-                  %input{class:"hidden-field", type: "file", name: "item[images_attributes][3][image]", id: "item_images_attributes_3_image" }
+                  %label{for: "item_images_attributes_0_image", class: "label-box", id: "label-box--0"}
+                    %pre.label-box__text-visible クリックしてファイルをアップロード
+                  .hidden-content
+                    = f.fields_for :images do |i|
+                      = i.file_field :image, class: "hidden-field"
+                      %input{class:"hidden-field", type: "file", name: "item[images_attributes][1][image]", id: "item_images_attributes_1_image" }
+                      %input{class:"hidden-field", type: "file", name: "item[images_attributes][2][image]", id: "item_images_attributes_2_image" }
+                      %input{class:"hidden-field", type: "file", name: "item[images_attributes][3][image]", id: "item_images_attributes_3_image" }
           
               %hr
               .column_title


### PR DESCRIPTION
# WHAT
・商品出品ページの写真投稿フォームのビューを修正いたしました

# WHY
・初期設定のフォームが表示されており、不格好だったため

[![Image from Gyazo](https://i.gyazo.com/cd9340e4fd560b642dfd023b6950cb98.gif)](https://gyazo.com/cd9340e4fd560b642dfd023b6950cb98)