### PR TITLE
商品写真のない場合のエラーハンドリング

### DIFF
--- a/app/assets/javascripts/card.coffee
+++ b/app/assets/javascripts/card.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/images.coffee
+++ b/app/assets/javascripts/images.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/items.coffee
+++ b/app/assets/javascripts/items.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/purchase.coffee
+++ b/app/assets/javascripts/purchase.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -73,18 +73,22 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    if @item.save!
-      redirect_to item_path(@item.id)
-    else
-      render :new
+    if @item.images.present?
+      if @item.save!
+        redirect_to item_path(@item.id)
+      else
+        render :new
+      end
     end
   end
 
   def update
-    if @item.update(item_params)
-      redirect_to root_path
-    else
-      render :edit
+    if @item.images.present?
+      if @item.update(item_params)
+        redirect_to item_path(@item.id)
+      else
+        render :edit
+      end
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -74,21 +74,25 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.images.present?
-      if @item.save!
-        redirect_to item_path(@item.id)
+      if @item.save
+        redirect_to root_path, notice: "商品を出品しました！"
       else
-        render :new
+        redirect_to new_item_path, alert: "未入力の項目があります！"
       end
+    else
+      redirect_to new_item_path, alert: "未入力の項目があります！"
     end
   end
-
+  
   def update
     if @item.images.present?
       if @item.update(item_params)
-        redirect_to item_path(@item.id)
+        redirect_to root_path, notice: "商品の編集が完了しました！"
       else
-        render :edit
+        redirect_to new_item_path, alert: "未入力の項目があります！"
       end
+    else
+      redirect_to new_item_path, alert: "未入力の項目があります！"
     end
   end
 
@@ -106,7 +110,8 @@ class ItemsController < ApplicationController
 private
   def item_params
     params.require(:item).permit(
-      :seller_id, :category_id, :name, :description, :postage_id, :region_id, :shipping_date_id, :price, :condition_id, :status, [images_attributes: [:image, :_destroy, :id]]
+      :seller_id, :category_id, :name, :description, :postage_id, :region_id, :shipping_date_id, 
+      :price, :condition_id, :status, [images_attributes: [:image, :_destroy, :id]]
     )
   end
       

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,6 @@
 class Image < ApplicationRecord
   mount_uploader :image, ImageUploader
+  validates :image, presence: true
 
-  belongs_to :item
+  belongs_to :item, optional: true
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,5 +2,5 @@ class Image < ApplicationRecord
   mount_uploader :image, ImageUploader
   validates :image, presence: true
 
-  belongs_to :item, optional: true
+  belongs_to :item
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,10 +1,11 @@
 class Item < ApplicationRecord
 
   has_many :images, dependent: :destroy
-  belongs_to :user,foreign_key: 'seller_id'
-
   # item保存時に、imageテーブルにレコードを保存するため
   accepts_nested_attributes_for :images, allow_destroy: true # itemが削除された時に紐づくimageも消すため 
+  
+  belongs_to :user,foreign_key: 'seller_id'
+
   extend ActiveHash::Associations::ActiveRecordExtensions
     belongs_to_active_hash :region
     belongs_to_active_hash :condition

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,7 @@ class Item < ApplicationRecord
     belongs_to_active_hash :postage
     belongs_to_active_hash :shipping_date
   
-    validates :name, :price, :condition_id, :postage_id, :region_id, :shipping_date_id, :description, :seller_id, :status, :category_id, presence: true
+  validates :name, :price, :condition_id, :postage_id, :region_id, :shipping_date_id, :description, :seller_id, :status, :category_id, presence: true
 
   def self.search(search)
     return Item.all unless search

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -35,7 +35,6 @@
                             .delete-btn
                               %span 削除
                   .label-content
-
                     //プレビューの数に合わせてforオプションを指定
                     = f.label :"images_attributes_#{@item.images.length}_image", class: "label-box", id: "label-box--#{@item.images.length}" do
                       %pre.label-box__text-visible クリックしてファイルをアップロード


### PR DESCRIPTION
# WHAT
・商品写真がない状態で、商品出品・編集をした場合に保存できない仕様に変更
・items_controllerに@item.images.present?の記述を追加

# WHY
・商品写真がない状態で出品すると、その他のページでエラーが発生するため

[![Image from Gyazo](https://i.gyazo.com/99f229d7161cacec754f8e80565be273.gif)](https://gyazo.com/99f229d7161cacec754f8e80565be273)