### PR TITLE
商品編集ページ・写真削除された状態では更新できないよう改修

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,11 +89,11 @@ class ItemsController < ApplicationController
   end
   
   def update
-    if @item.images.present?
-      if @item.update(item_params)
+    if @item.update(item_params)
+      if @item.images.present?
         redirect_to root_path, notice: "商品の編集が完了しました！"
       else
-        redirect_to new_item_path, alert: "未入力の項目があります！"
+        render :edit, alert: "未入力の項目があります！"
       end
     else
       redirect_to new_item_path, alert: "未入力の項目があります！"


### PR DESCRIPTION
# WHAT
・商品編集ページで写真を全削除した状態では更新できないようにバリデーションを改修

！！　JSの記述でバリデーションをかけないと、登録内容を保持したまま編集ページに戻すことができなさそうなのでそこの実装は諦めています

# WHY
・商品写真を全削除して更新するとエラーが表示される仕様になっていたため

[![Image from Gyazo](https://i.gyazo.com/69d925211216f934e817b8841af85d88.gif)](https://gyazo.com/69d925211216f934e817b8841af85d88)